### PR TITLE
build(proto): add go-lite regeneration workflow 🧰

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+*_vtproto.pb.go
 
 # Dependency directories (remove the comment below to include it)
 # vendor/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+PROTO_DEFINITIONS_DIR ?= ../protobuf-definitions
+MODULE_PATH := github.com/tarmac-project/protobuf-go
+GENERATED_DIR := $(PROTO_DEFINITIONS_DIR)/build/go/$(MODULE_PATH)
+GENERATED_SDK_DIR := $(GENERATED_DIR)/sdk
+
+.PHONY: build generate clean test verify
+
+build: generate
+
+generate:
+	@echo "Generating protobuf Go packages from $(PROTO_DEFINITIONS_DIR)..."
+	@test -d "$(PROTO_DEFINITIONS_DIR)" || (echo "missing PROTO_DEFINITIONS_DIR: $(PROTO_DEFINITIONS_DIR)" && exit 1)
+	@$(MAKE) -C "$(PROTO_DEFINITIONS_DIR)" build
+	@test -d "$(GENERATED_SDK_DIR)" || (echo "missing generated output: $(GENERATED_SDK_DIR)" && exit 1)
+	rsync -a --delete "$(GENERATED_SDK_DIR)/" ./sdk/
+
+test:
+	go test ./...
+
+verify: generate test
+	git diff --exit-code
+
+clean:
+	@echo "Cleaning local protobuf-go artifacts..."
+	find . -type f -name "*.test" -delete
+	find . -type f -name "coverage.out" -delete

--- a/README.md
+++ b/README.md
@@ -2,8 +2,31 @@
 
 [![GoDoc](https://godoc.org/github.com/tarmac-project/protobuf-go?status.svg)](https://godoc.org/github.com/tarmac-project/protobuf-go)
 
-This repository contains generated Go packages for interacting with [Tarmac](https://github.com/tarmac-project/tarmac) via Protobuf.
+This repository contains generated Go packages for interacting with
+[Tarmac](https://github.com/tarmac-project/tarmac) via Protobuf.
 
-The source Protobuf files are located in the [protobuf-definitions](https://github.com/tarmac-project/protobuf-definitions) repository.
+The source Protobuf files are located in the
+[protobuf-definitions](https://github.com/tarmac-project/protobuf-definitions)
+repository.
 
-While the packages within this repository are generally meant for internal tooling users of Tarmac may find them useful.
+The generated packages in this repository are produced with
+`protoc-gen-go-lite`. The generated APIs include helpers such as `MarshalVT`
+and `UnmarshalVT`, but those helpers are provided by go-lite in this repo's
+current toolchain.
+
+## Regenerating Code
+
+Run `make build` from this repository to regenerate the checked-in Go files from
+`../protobuf-definitions`.
+
+If the definitions repository is located elsewhere, override the source path:
+
+```console
+make build PROTO_DEFINITIONS_DIR=/path/to/protobuf-definitions
+```
+
+The build target regenerates code from the schema source and syncs the generated
+`*.pb.go` files into this repository's `sdk/` tree.
+
+While the packages within this repository are generally meant for internal
+tooling, users of Tarmac may also find them useful.


### PR DESCRIPTION
## Summary
Add the local regeneration path and documentation needed to keep protobuf-go aligned with go-lite-generated output from protobuf-definitions.

## Changes
- add a root Makefile that regenerates from ../protobuf-definitions and syncs the sdk tree
- document the go-lite generator contract in the README
- ignore stray *_vtproto.pb.go artifacts so the repo stays on the go-lite path

## Rationale
protobuf-go already checks in go-lite-generated pb.go files, but it lacked a repo-local regeneration entrypoint and still had enough vtproto drift to make cleanup fragile.

## Risk & Impact
- Breaking changes: no public API change intended; this clarifies the existing generator path
- Performance/Security: no runtime behavior change; generation and repo hygiene only
